### PR TITLE
fix work with windows line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ usage: goimportssort [flags] [path ...]
 (default tries to get module name of current directory)
   -v    verbose logging (default false)
   -w    write result to (source) file (default false)
+  -win  replace windows line breaks to unix format (otherwise all line breaks will be removed)
 ```
 Imports will be sorted according to their categories.
 ```

--- a/goimportssort.go
+++ b/goimportssort.go
@@ -32,8 +32,11 @@ var (
 	list             = flag.Bool("l", false, "write results to stdout")
 	write            = flag.Bool("w", false, "write result to (source) file instead of stdout")
 	localPrefix      = flag.String("local", "", "put imports beginning with this string after 3rd-party packages; comma-separated list")
+	winLines         = flag.Bool("win", false, "replace windows line breaks to unix format")
 	verbose          bool // verbose logging
 	standardPackages = make(map[string]struct{})
+	newLineWin       = []byte("\r\n")
+	newLineUnix      = []byte("\n")
 )
 
 // impModel is used for storing import information
@@ -147,6 +150,10 @@ func processFile(filename string, in io.Reader, out io.Writer) ([]byte, error) {
 	src, err := ioutil.ReadAll(in)
 	if err != nil {
 		return nil, err
+	}
+
+	if *winLines {
+		src = bytes.Replace(src, newLineWin, newLineUnix, -1)
 	}
 
 	res, err := process(src)

--- a/goimportssort_test.go
+++ b/goimportssort_test.go
@@ -196,3 +196,19 @@ func TestGetModuleName(t *testing.T) {
 
 	asserts.Equal("github.com/AanZee/goimportssort", name)
 }
+
+func TestWithEmptyLines(t *testing.T) {
+	asserts := assert.New(t)
+	*localPrefix = "github.com/AanZee/goimportssort"
+	*winLines = true
+	reader := strings.NewReader("package main\r\n\r\nimport (\r\n\t\"fmt\"\r\n\t\"log\"\r\n\r\n\t\"bitbucket.org/example/package/name2\"\r\n\t\r\n\t\"net/http\"\r\n)\r\n\r\nfunc main() {\r\n\tfmt.Println(\"Hello!\")\r\n\r\n\tif true {\r\n\t\tfmt.Println(\"Its true\")\r\n\t}\r\n}\r\n")
+	want := "package main\n\nimport (\n\t\"fmt\"\n\t\"log\"\n\t\"net/http\"\n\n\t\"bitbucket.org/example/package/name2\"\n)\n\nfunc main() {\n\tfmt.Println(\"Hello!\")\n\n\tif true {\n\t\tfmt.Println(\"Its true\")\n\t}\n}\n"
+
+	output, err := processFile("", reader, os.Stdout)
+	asserts.NotEqual(nil, output)
+	asserts.Equal(nil, err)
+
+	asserts.Equal(want, string(output))
+
+	*winLines = false
+}


### PR DESCRIPTION
I found bug: if file with windows line breaks (\r\n), all line breaks will be removed after imports sorting.

I created new flag for this case, by default there will be no change. And i created new test with my case.